### PR TITLE
Add rails template to be able to initialize alchemy_cms app with minimal effort

### DIFF
--- a/public/new
+++ b/public/new
@@ -1,0 +1,9 @@
+gem 'alchemy_cms'
+gem 'alchemy-devise'
+
+after_bundle do
+  rails_command 'alchemy:install'
+  generate 'alchemy:devise:install'
+
+  rails_command 'db:migrate'
+end


### PR DESCRIPTION
Thanks to this file, users can be instructed that it's possible to initialize a new alchemy_cms-based app using just:

```
rails new -m https://alchemy-cms.com/new YOUR-APP-NAME
```

I prepared the simplest setup possible so users can jump right in fast but it could probably be more rails-version aware (different template variants for different rails/alchemy versions etc) but, no matter what, this simple change simplifies entire guides page about installing into one simple step which should be enough for a lot of folks wanting to try the alchemy goodness. 

Regarding discussion in: https://github.com/AlchemyCMS/alchemy_cms/issues/1715